### PR TITLE
feat(maven) update archetype groupid

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The archetype is now installed on your local maven repository, and is ready to b
  _Make sure that you do not launch the command from an existing maven project._
  
 ```
-mvn archetype:generate -DarchetypeGroupId=org.bonitasoft.archertypes -DarchetypeArtifactId=bonita-connector-archetype -DarchetypeVersion=1.0.0-SNAPSHOT -DgroupId=myGroupId -DartifactId=myArtifactId -Dversion=1.0-SNAPSHOT -DconnectorName=myConnector -DbonitaVersion=7.10.0 -Dlanguage=java
+mvn archetype:generate -DarchetypeGroupId=org.bonitasoft.archetypes -DarchetypeArtifactId=bonita-connector-archetype -DarchetypeVersion=1.0.0-SNAPSHOT -DgroupId=myGroupId -DartifactId=myArtifactId -Dversion=1.0-SNAPSHOT -DconnectorName=myConnector -DbonitaVersion=7.10.0 -Dlanguage=java
 ```
 
  - **archetypeGroupId:** the group id of the connector archetype, cannot be changed.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The archetype is now installed on your local maven repository, and is ready to b
  _Make sure that you do not launch the command from an existing maven project._
  
 ```
-mvn archetype:generate -DarchetypeGroupId=org.bonitasoft.connectors -DarchetypeArtifactId=bonita-connector-archetype -DarchetypeVersion=1.0.0-SNAPSHOT -DgroupId=myGroupId -DartifactId=myArtifactId -Dversion=1.0-SNAPSHOT -DconnectorName=myConnector -DbonitaVersion=7.10.0 -Dlanguage=java
+mvn archetype:generate -DarchetypeGroupId=org.bonitasoft.archertypes -DarchetypeArtifactId=bonita-connector-archetype -DarchetypeVersion=1.0.0-SNAPSHOT -DgroupId=myGroupId -DartifactId=myArtifactId -Dversion=1.0-SNAPSHOT -DconnectorName=myConnector -DbonitaVersion=7.10.0 -Dlanguage=java
 ```
 
  - **archetypeGroupId:** the group id of the connector archetype, cannot be changed.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The archetype is now installed on your local maven repository, and is ready to b
  _Make sure that you do not launch the command from an existing maven project._
  
 ```
-mvn archetype:generate -DarchetypeGroupId=org.bonitasoft -DarchetypeArtifactId=bonita-connector-archetype -DarchetypeVersion=1.0.0-SNAPSHOT -DgroupId=myGroupId -DartifactId=myArtifactId -Dversion=1.0-SNAPSHOT -DconnectorName=myConnector -DbonitaVersion=7.10.0 -Dlanguage=java
+mvn archetype:generate -DarchetypeGroupId=org.bonitasoft.connectors -DarchetypeArtifactId=bonita-connector-archetype -DarchetypeVersion=1.0.0-SNAPSHOT -DgroupId=myGroupId -DartifactId=myArtifactId -Dversion=1.0-SNAPSHOT -DconnectorName=myConnector -DbonitaVersion=7.10.0 -Dlanguage=java
 ```
 
  - **archetypeGroupId:** the group id of the connector archetype, cannot be changed.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
  
-  <groupId>org.bonitasoft</groupId>
+  <groupId>org.bonitasoft.connectors</groupId>
   <artifactId>bonita-connector-archetype</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
  
-  <groupId>org.bonitasoft.connectors</groupId>
+  <groupId>org.bonitasoft.archertypes</groupId>
   <artifactId>bonita-connector-archetype</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
  
-  <groupId>org.bonitasoft.archertypes</groupId>
+  <groupId>org.bonitasoft.archetypes</groupId>
   <artifactId>bonita-connector-archetype</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>


### PR DESCRIPTION
This archetype will be deployed on maven central. We already have some
artifacts with the group id 'org.bonitasoft.connectors' on central, so
it make sense to keep this group id.