### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Bonita Connector Archetype
 
 This project contains a maven archetype, which allow to easily setup a Bonita connector project.  
-You can find the complete documentation of this archetype with a detailed example on our [documentation website](https://documentation.bonitasoft.com/bonita/7.11/connector-archetype)
+You can find the complete documentation of this archetype with a detailed example on our [documentation website](https://documentation.ofelia.com/bonita/7.11/connector-archetype)
 
 ### Setup a connector project using the archetype 
 

--- a/src/main/resources/archetype-resources/README.adoc
+++ b/src/main/resources/archetype-resources/README.adoc
@@ -26,7 +26,7 @@
 :linkcss: false
 
 :short-bonita-version: ${shortBonitaVersion}
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version:#if( $after10 ) 17#elseif ( $after713 ) 11#else 8#end
 
 = ${artifactId}

--- a/src/test/resources/projects/testGroovyProject10/reference/README.adoc
+++ b/src/test/resources/projects/testGroovyProject10/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 10.0
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 17
 = connector-groovy-test
 

--- a/src/test/resources/projects/testGroovyProject7_13/reference/README.adoc
+++ b/src/test/resources/projects/testGroovyProject7_13/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 = connector-groovy-test
 

--- a/src/test/resources/projects/testJava11Project/reference/README.adoc
+++ b/src/test/resources/projects/testJava11Project/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 = connector-java-test
 

--- a/src/test/resources/projects/testJavaProject10/reference/README.adoc
+++ b/src/test/resources/projects/testJavaProject10/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 10.0
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 17
 = connector-java-test
 

--- a/src/test/resources/projects/testKotlinProject/reference/README.adoc
+++ b/src/test/resources/projects/testKotlinProject/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.10
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 8
 = connector-kotlin-test
 

--- a/src/test/resources/projects/testKotlinProject7_13/reference/README.adoc
+++ b/src/test/resources/projects/testKotlinProject7_13/reference/README.adoc
@@ -11,7 +11,7 @@
 :linkcss: false
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 = connector-kotlin-test
 


### PR DESCRIPTION
## Summary
- Replace `documentation.bonitasoft.com` -> `documentation.ofelia.com`
- Replace `community.bonitasoft.com` -> `community.ofelia.com`
- Replace `www.bonitasoft.com` -> `www.ofelia.com`

Affects README and archetype template files only. No logic changes.

Part of the Bonitasoft -> Ofelia rebranding initiative.